### PR TITLE
fix: wrap log if too long, to prevent overflow

### DIFF
--- a/src/pages/manage/logs.rs
+++ b/src/pages/manage/logs.rs
@@ -218,7 +218,7 @@ fn LogItem(log: LogEntry) -> impl IntoView {
             </ListItem>
 
             <ListItem>
-                <span class="text-sm text-gray-500">{log.message}</span>
+                <span class="text-sm text-gray-500 text-wrap">{log.message}</span>
             </ListItem>
 
         </tr>


### PR DESCRIPTION
This minor fix should prevent overflow in the logs page, inherited by the whitespace-wrap used to remove spaces between words. 