### PR TITLE
Use the TailwindCSS darkMode `media` query strategy.

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -31,6 +31,6 @@ module.exports = {
       },
     },
   },
-  darkMode: 'class',
+  darkMode: 'media',
   plugins: [require('@tailwindcss/forms'), require("@tailwindcss/typography"), require("preline/plugin")],
 }


### PR DESCRIPTION
Enables the TailwindCSS dark mode automatically for user agents that prefer dark colour scheme.

Related: https://github.com/stalwartlabs/mail-server/issues/455