### PR TITLE
fix text rendering

### DIFF
--- a/src/components/list/pagination.rs
+++ b/src/components/list/pagination.rs
@@ -47,7 +47,9 @@ pub fn Pagination(
                         </select>
                     </div>
 
-                    <p class="text-sm text-gray-600 dark:text-gray-400">of {total_pages}</p>
+                    <p class="text-sm text-gray-600 dark:text-gray-400">
+                        "of " {total_pages}
+                    </p>
                 </div>
 
             </Show>


### PR DESCRIPTION
space missing between "of" and total page number, due to leptos string handling during rendering
<img width="277" alt="Screenshot 2024-08-06 at 22 41 03" src="https://github.com/user-attachments/assets/bd53a980-e3b3-4d72-95cf-ec878dbbe5a2">
