### PR TITLE
Support Azure blob storage in a similar fashion to S3

### DIFF
--- a/src/pages/config/schema/storage.rs
+++ b/src/pages/config/schema/storage.rs
@@ -55,6 +55,7 @@ impl Builder<Schemas, ()> {
                 "sqlite",
                 "rocksdb",
                 "s3",
+                "azure",
                 "fs",
                 "sql-read-replica",
                 "distributed-blob",


### PR DESCRIPTION
This is a followup to https://github.com/stalwartlabs/mail-server/pull/907 (and its followup https://github.com/stalwartlabs/mail-server/pull/910) where Azure blob storage support was added. It's quite similar to S3, and a couple of field definitions (`max-retries` and `key-prefix`) have been pulled out of the S3-specific stanza and are now shared between S3 and Azure.

Web applications aren't my strongest suit; I've tested this and it seems like it works, but please let me know if I did something dumb.

Thanks!!