### PR TITLE
Fix invalid concatenation of long DKIM records in Zonefile

### DIFF
--- a/src/pages/directory/dns.rs
+++ b/src/pages/directory/dns.rs
@@ -66,12 +66,7 @@ fn format_zonefile(records: &[DnsRecord], domain: &str) -> String {
             width2 = max_len[1]
         );
         if x[1] == "TXT" {
-            x[2].as_bytes()
-                .chunks(255)
-                .fold(key, |acc, x| {
-                    format!("{} \"{}\"", acc, String::from_utf8_lossy(x))
-                })
-                .add("\n")
+            format!("{} \"{}\"\n", key, String::from_utf8_lossy(x[2].as_bytes())).add("\n")
         } else {
             format!("{} {}\n", key, x[2])
         }


### PR DESCRIPTION
Hi,

The Zonefile feature is pretty useful but there is an issue with TXT records concatenation.

For example, the DKIM record for the public key generated for the RSA algorithm is longer than the `255` byte chunk length, which causes it to break and join as an additional string while it should be a single continuous one:

<img width="299" alt="image" src="https://github.com/user-attachments/assets/8511033f-3e26-4f7e-b8c1-013d97e6c851" />

This has caused issues with the record when copying & pasting the file as it is without inspection.

The value on the records table is good though.