### PR TITLE
Add IP Strategy Dropdown

### DIFF
--- a/src/pages/config/schema/smtp.rs
+++ b/src/pages/config/schema/smtp.rs
@@ -129,6 +129,15 @@ impl Builder<Schemas, ()> {
                 "emails to a remote SMTP server"
             ))
             .default("ipv4_then_ipv6")
+            .typ(Type::Select {
+                typ: SelectType::Single,
+                source: Source::Static(&[
+                    ("ipv4_only", "IPv4 Only"),
+                    ("ipv6_only", "IPv6 Only"),
+                    ("ipv4_then_ipv6", "IPv4 then IPv6"),
+                    ("ipv6_then_ipv4", "IPv6 then IPv4"),
+                ]),
+            })
             .input_check(
                 [],
                 [

--- a/src/pages/config/schema/smtp.rs
+++ b/src/pages/config/schema/smtp.rs
@@ -151,6 +151,7 @@ impl Builder<Schemas, ()> {
                 "Determines a list of local IPv4 addresses to use when ",
                 "delivery emails to remote SMTP servers"
             ))
+            .typ(Type::Expression)
             .input_check([], [Validator::IsValidExpression(mx_vars)])
             .new_field("queue.outbound.source-ip.v6")
             .label("IPv6 addresses")


### PR DESCRIPTION
The selector for IP Strategy in **Settings** -> **SMTP** -> **Outbound** -> **Routing** currently is just a text field with some hidden validations. This changes it to a dropdown with the 4 valid options: `ipv4_only`, `ipv6_only`, `ipv4_then_ipv6`, and `ipv6_then_ipv4`.

I have the following log showing it being tested:
[stalwart.log.2025-05-27.validation.log](https://github.com/user-attachments/files/20447654/stalwart.log.2025-05-27.validation.log)

There are 5 lines that contain the text `Connecting to remote server`.
The 1st is with `ipv4_only`, connecting to GMail over IPv4.
The 2nd is with `ipv6_only`, connecting to GMail over IPv6.
The 3rd is with `ipv4_then_ipv6`, connecting to GMail over IPv4.
The 4th is with `ipv6_then_ipv4`, connecting to GMail over IPv6.
The 5th is with `ipv6_then_ipv4`, connecting to Proton over IPv4 (they don't have an AAAA record for their email server).

The updated UI looks like ![UI Preview of this PR showing the dropdown selector for "IPv6 then IPv4"](https://github.com/user-attachments/assets/a4331b42-1847-41d9-8387-ab084adffe70)