### PR TITLE
Add timeout-minutes to build file

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
Set a build timeout of 10 minutes. It only takes about 2 minutes to run in my experience. By default GitHub can get stuck running for up to 12 or 24 hours.

I noticed this when using the pipeline to build another PR for testing.

It's just one of those things I learned to do after getting an email from my boss one morning telling me the company had run out of action minutes because a test pipeline got stuck running for 12 hours.

I'd highly recommend reviewing the pipeline files on all of your repos.