### PR TITLE
Fix dav-card-prop-find label to indicate it's CardDAV.

### DIFF
--- a/src/pages/directory/mod.rs
+++ b/src/pages/directory/mod.rs
@@ -986,7 +986,7 @@ pub static PERMISSIONS: &[(&str, &str)] = &[
     ),
     (
         "dav-card-prop-find",
-        "FileDAV - Retrieve properties of address book entries",
+        "CardDAV - Retrieve properties of address book entries",
     ),
     (
         "dav-card-prop-patch",


### PR DESCRIPTION
At the moment, this is listed as FileDAV, which is confusingly wrong. :)