### PR TITLE
Add batch size field to webhook settings

### DIFF
--- a/src/pages/config/schema/server.rs
+++ b/src/pages/config/schema/server.rs
@@ -483,6 +483,19 @@ impl Builder<Schemas, ()> {
             .typ(Type::Duration)
             .input_check([], [Validator::Required])
             .build()
+            .new_field("batch-size")
+            .label("Batch Size")
+            .help(concat!(
+                "Maximum number of events to include in each webhook request. ",
+                "Larger batches reduce HTTP overhead but increase payload size"
+            ))
+            .default("100")
+            .typ(Type::Input)
+            .input_check(
+                [Transformer::Trim],
+                [Validator::Required, Validator::MinValue(1.into())],
+            )
+            .build()
             .new_field("signature-key")
             .label("Signature Key")
             .help(concat!(
@@ -533,7 +546,7 @@ impl Builder<Schemas, ()> {
             .build()
             .new_form_section()
             .title("Options")
-            .fields(["throttle", "timeout", "headers"])
+            .fields(["throttle", "timeout", "batch-size", "headers"])
             .build()
             .list_title("Webhooks")
             .list_subtitle("Manage Webhooks")


### PR DESCRIPTION
## Summary

Adds the `batch-size` configuration option to the webhook settings UI, allowing users to control how many events are sent per webhook request.

This is the UI companion to stalwartlabs/stalwart#2503.

## Changes

- Added batch-size input field to webhook settings form
- Field appears under the "Options" section alongside throttle and timeout
- Defaults to 100, minimum value of 1